### PR TITLE
Correct typo in throw_status_code_exception

### DIFF
--- a/lib/Client.rb
+++ b/lib/Client.rb
@@ -90,7 +90,7 @@ class Client
       when '500'
         raise ServerError, message
       when '503'
-        raise DownForMaintenanceErroressage, message
+        raise DownForMaintenanceError, message
       else
         raise UnexpectedError, message
       end


### PR DESCRIPTION
Noticed while looking over https://github.com/PaymentRails/ruby-sdk/blob/dev/lib/Exceptions.rb