### PR TITLE
Relax RestClient version requirement to 2.0.0

### DIFF
--- a/paymentrails.gemspec
+++ b/paymentrails.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.author = "PaymentRails"
   s.has_rdoc = false
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
-  s.add_dependency "rest-client", "= 2.0.2"
+  s.add_dependency "rest-client", ">= 2.0.0"
 end


### PR DESCRIPTION
Unless there is some specific reason why you need 2.0.2?