### PR TITLE
Always verify SSL if baseURI starts with https

### DIFF
--- a/lib/paymentrails/Client.rb
+++ b/lib/paymentrails/Client.rb
@@ -35,12 +35,7 @@ module PaymentRails
     def send_request(endPoint, method, body = '')
       uri = URI.parse(@config.apiBase + endPoint)
       http = Net::HTTP.new(uri.host, uri.port)
-
-      # for ssl use
-      if (@config.apiBase["https"])
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      end
+      http.use_ssl = @config.useSsl?
 
       time = Time.now.to_i
       headers = {'X-PR-Timestamp': time.to_s,

--- a/lib/paymentrails/Configuration.rb
+++ b/lib/paymentrails/Configuration.rb
@@ -4,11 +4,11 @@ module PaymentRails
     def initialize(publicKey, privateKey, environment = 'production')
       @publicKey = publicKey
       @privateKey = privateKey
-      @apiBase = set_environment(environment)
+      @environment = environment
     end
 
-    def set_environment(apiBase)
-      case apiBase
+    def apiBase
+      case environment
       when 'production'
         'https://api.paymentrails.com'
       when 'development'
@@ -20,6 +20,10 @@ module PaymentRails
       end
     end
 
+    def useSsl?
+      apiBase.start_with? 'https'
+    end
+
     attr_reader :publicKey
 
     attr_writer :publicKey
@@ -28,6 +32,6 @@ module PaymentRails
 
     attr_writer :privateKey
 
-    attr_reader :apiBase
+    attr_reader :environment
   end
 end


### PR DESCRIPTION
Trying to understand why we wouldn't verify SSL in the case of an HTTPS base. Feels like that defeats the purpose of using SSL altogether.

Cert for production is valid:

![image](https://user-images.githubusercontent.com/1264305/67350716-62ecc500-f500-11e9-91fe-ca5d6e6c3dda.png)

I made `useSsl?` a method in case there's some exceptions to that rule (test/sandbox environment).