### PR TITLE
[BUG] Typo in RecipientAccount gateway causes update to fail

### DIFF
--- a/lib/paymentrails/gateways/RecipientAccountGateway.rb
+++ b/lib/paymentrails/gateways/RecipientAccountGateway.rb
@@ -22,7 +22,7 @@ module PaymentRails
     end
 
     def update(recipient_id, recipient_account_id, body)
-      response = @client.patch('/v1/recipients/' + recipient_id, + '/accounts/' + recipient_account_id, body)
+      response = @client.patch('/v1/recipients/' + recipient_id + '/accounts/' + recipient_account_id, body)
       recipient_account_builder(response)
     end
 


### PR DESCRIPTION
Pretty self explanatory -- this method accepts 2 arguments, not three.

This probably means we should have some tests