### PR TITLE
Rdoc flag is deprecated/removed

### DIFF
--- a/paymentrails.gemspec
+++ b/paymentrails.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.email = ['joshua@paymentrails.com']
   s.license = "MIT"
   s.author = "PaymentRails"
-  s.has_rdoc = false
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.add_dependency "rest-client", ">= 2.0.0"
 end


### PR DESCRIPTION
Deprecation notice when installing gem:

> NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/src/app/vendor/bundle/ruby/2.4.0/bundler/gems/ruby-sdk-f5133f1ca256/paymentrails.gemspec:12.

See https://blog.rubygems.org/2009/05/04/1.3.3-released.html