### PR TITLE
Missing Payment.estimatedDeliveryAt attribute

### DIFF
--- a/lib/paymentrails/Payment.rb
+++ b/lib/paymentrails/Payment.rb
@@ -21,6 +21,7 @@ module PaymentRails
       :merchantFees,
       :compliance,
       :payoutMethod,
+      :estimatedDeliveryAt,
       :recipient,
       :withholdingAmount,
       :withholdingCurrency,


### PR DESCRIPTION
```ruby
api_client.payment.search('B-111111111', 1, 1000)
```

Breaks because `estimatedDeliveryAt=` is not defined on the class but is in the payload. This is now the 2nd or 3rd time this has happened, I think it may be worth reconsidering the implementation of these classes. We have some ideas we can discuss further. 