### PR TITLE
Add proxy support & improve integration test setup

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,3 @@
+SANDBOX_API_KEY=fake_api_key
+SANDBOX_SECRET_KEY=fake_secret_key
+PROXY_URI=a_proxy_if_you_need_it

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Gemfile.lock
 .bundle
 vendor
 .vscode
+.env
+!.env.template

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,19 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowAdjacentOneLineDefs, NumberOfEmptyLines.
-Layout/EmptyLineBetweenDefs:
-  Exclude:
-    - 'spec/integration/RecipientAccountTest.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLines:
-  Exclude:
-    - 'spec/integration/RecipientAccountTest.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.
@@ -108,11 +95,6 @@ Lint/DuplicateMethods:
 Lint/UselessAccessModifier:
   Exclude:
     - 'lib/paymentrails/Client.rb'
-
-# Offense count: 2
-Lint/UselessAssignment:
-  Exclude:
-    - 'spec/integration/RecipientAccountTest.rb'
 
 # Offense count: 11
 Metrics/AbcSize:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,13 @@ First `bundle install`
 
 `bundle exec rake unit_tests`
 
-#### Running just the integration tests 
+#### Running just the integration tests
+
+Integration tests have a dependency on the real API, therefore you need credentials.
+
+To add credentials, this gem uses `dotenv` to inject credential ENV variables:
+
+1. copy the env template `cp .env.template .env`
+1. add your configuration there **NOTE: preferrably use sandbox values -- integration tests run real requests**
 
 `bundle exec rake integration_tests`

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ recipient = client.recipient.find('R-1234567abcdefg')
 print recipient.id
 ```
 
+#### Need a proxy?
+
+```Ruby
+client = PaymentRails.client('YOUR-API-KEY', 'YOUR-SECRET-KEY', 'development', proxy_uri: 'peter_the_proxy.com')
+```
+
 ## Documentation for API Endpoints
 
 All URIs are available at http://docs.paymentrails.com/

--- a/lib/paymentrails.rb
+++ b/lib/paymentrails.rb
@@ -18,8 +18,7 @@ require 'paymentrails/RecipientAccount'
 require 'paymentrails/OfflinePayment'
 
 module PaymentRails
-  def self.client(key, secret, environment = 'production')
-    client = Gateway.new(Configuration.new(key, secret, environment))
-    return client
+  def self.client(key, secret, environment = 'production', **optionals)
+    Gateway.new(Configuration.new(key, secret, environment, optionals))
   end
 end

--- a/lib/paymentrails/Client.rb
+++ b/lib/paymentrails/Client.rb
@@ -33,7 +33,10 @@ module PaymentRails
 
     def send_request(endPoint, method, body = '')
       uri = URI.parse(@config.apiBase + endPoint)
-      http = Net::HTTP.new(uri.host, uri.port)
+      http = Net::HTTP.new(
+        uri.host, uri.port,
+        @config.proxy&.host, @config.proxy&.port, @config.proxy&.user, @config.proxy&.password
+      )
       http.use_ssl = @config.useSsl?
 
       time = Time.now.to_i

--- a/lib/paymentrails/Configuration.rb
+++ b/lib/paymentrails/Configuration.rb
@@ -1,12 +1,19 @@
 module PaymentRails
   class Configuration
+    class InvalidProxyAddress < StandardError; end
 
-    def initialize(publicKey, privateKey, environment = 'production')
+    def initialize(publicKey, privateKey, environment = 'production', proxy_uri: nil)
       raise ArgumentError, 'Both key/secret must be a nonempty string' if publicKey.to_s&.empty? || privateKey.to_s&.empty?
 
       @publicKey = publicKey
       @privateKey = privateKey
       @environment = environment
+      # failfast on a bad proxy
+      begin
+        @proxy = proxy_uri.nil? ? nil : URI.parse(proxy_uri)
+      rescue URI::InvalidURIError
+        raise InvalidProxyAddress, "Invalid proxy provided to configuration: #{proxy_uri}"
+      end
     end
 
     def apiBase
@@ -25,6 +32,8 @@ module PaymentRails
     def useSsl?
       apiBase.start_with? 'https'
     end
+
+    attr_reader :proxy
 
     attr_reader :publicKey
 

--- a/paymentrails.gemspec
+++ b/paymentrails.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.author = "PaymentRails"
   s.files = Dir.glob ["README.rdoc", "LICENSE", "lib/**/*.{rb,crt}", "spec/**/*", "*.gemspec"]
   s.required_ruby_version = '>= 2.4'
+  s.add_development_dependency 'dotenv', '~> 2'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency "rubocop", '~> 0.77'
   s.add_development_dependency 'test-unit', '~> 3'

--- a/spec/integration/BatchTest.rb
+++ b/spec/integration/BatchTest.rb
@@ -1,10 +1,13 @@
-require_relative '../../lib/paymentrails'
-require 'test/unit'
-require 'securerandom'
+require_relative 'helper'
 
 class BatchTest < Test::Unit::TestCase
   def setup
-    @client = PaymentRails::Gateway.new(PaymentRails::Configuration.new('YOUR-API-KEY', 'YOUR-SECRET-KEY'))
+    @client = PaymentRails.client(
+      ENV.fetch('SANDBOX_API_KEY'),
+      ENV.fetch('SANDBOX_SECRET_KEY'),
+      'production',
+      proxy_uri: ENV['PROXY_URI']
+    )
   end
 
   def create_recipient

--- a/spec/integration/RecipientTest.rb
+++ b/spec/integration/RecipientTest.rb
@@ -1,10 +1,13 @@
-require_relative '../../lib/paymentrails'
-require 'test/unit'
-require 'securerandom'
+require_relative 'helper'
 
 class RecipientTest < Test::Unit::TestCase
   def setup
-    @client = PaymentRails::Gateway.new(PaymentRails::Configuration.new('YOUR-API-KEY', 'YOUR-SECRET-KEY'))
+    @client = PaymentRails.client(
+      ENV.fetch('SANDBOX_API_KEY'),
+      ENV.fetch('SANDBOX_SECRET_KEY'),
+      'production',
+      proxy_uri: ENV['PROXY_URI']
+    )
   end
 
   def test_create

--- a/spec/integration/helper.rb
+++ b/spec/integration/helper.rb
@@ -1,0 +1,4 @@
+require 'dotenv/load'
+require_relative '../../lib/paymentrails'
+require 'test/unit'
+require 'securerandom'

--- a/spec/unit/ConfigurationTest.rb
+++ b/spec/unit/ConfigurationTest.rb
@@ -33,4 +33,19 @@ class ConfigurationTest < Test::Unit::TestCase
     assert_equal true, PaymentRails::Configuration.new('key', 'secret', 'development').useSsl?
     assert_equal true, PaymentRails::Configuration.new('key', 'secret', 'non_standard_environment').useSsl?
   end
+
+  def test_invalid_proxy_uri
+    proxy_uri = 'not_://*a_valid_proxy'
+    assert_raise PaymentRails::Configuration::InvalidProxyAddress.new("Invalid proxy provided to configuration: #{proxy_uri}") do
+      PaymentRails::Configuration.new('k', 's', 'production', proxy_uri: proxy_uri).proxy
+    end
+  end
+
+  def test_vaid_proxy_uri
+    config = PaymentRails::Configuration.new('k', 's', 'production', proxy_uri: 'http://user:pass@gimmeproxy.com:80')
+    assert_equal 'gimmeproxy.com', config.proxy.host
+    assert_equal 80, config.proxy.port
+    assert_equal 'user', config.proxy.user
+    assert_equal 'pass', config.proxy.password
+  end
 end

--- a/spec/unit/PaymentRailsTest.rb
+++ b/spec/unit/PaymentRailsTest.rb
@@ -3,6 +3,13 @@ require 'test/unit'
 
 class PaymentRailsTest < Test::Unit::TestCase
   def test_client
-    PaymentRails.client('key', 'secret', 'environment')
+    PaymentRails.client('key', 'secret', 'environment', proxy_uri: 'http://user:pass@gimmeproxy.com:80')
+  end
+
+  def test_client_invalid_proxy_uri
+    proxy_uri = 'not_://*a_valid_proxy'
+    assert_raise PaymentRails::Configuration::InvalidProxyAddress.new("Invalid proxy provided to configuration: #{proxy_uri}") do
+      PaymentRails.client('k', 's', 'production', proxy_uri: proxy_uri)
+    end
   end
 end


### PR DESCRIPTION
### Proxy support

1. Add (optional) proxy support
1. Fails fast when the proxy is misconfigured

### Run integration tests locally

1. Add dependency on `dotenv` in development
1. Allows us to inject API keys so that we can run the integration tests locally