### PR TITLE
Fix all setters, future-proof setter patterns

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,10 +86,6 @@ Layout/TrailingWhitespace:
   Exclude:
     - 'spec/integration/RecipientAccountTest.rb'
 
-# Offense count: 5
-Lint/DuplicateMethods:
-  Enabled: false
-
 # Offense count: 2
 # Configuration parameters: ContextCreatingMethods, MethodCreatingMethods.
 Lint/UselessAccessModifier:

--- a/lib/paymentrails/Batch.rb
+++ b/lib/paymentrails/Batch.rb
@@ -1,6 +1,20 @@
 module PaymentRails
   class Batch
-    attr_accessor	:id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :quoteExpiredAt, :payments, :tags, :coverFees
-    attr_writer :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :quoteExpiredAt, :payments, :tags, :coverFees
+    attr_accessor(
+      :id,
+      :amount,
+      :completedAt,
+      :createdAt,
+      :currency,
+      :description,
+      :sentAt,
+      :status,
+      :totalPayments,
+      :updatedAt,
+      :quoteExpiredAt,
+      :payments,
+      :tags,
+      :coverFees
+    )
   end
 end

--- a/lib/paymentrails/BatchSummary.rb
+++ b/lib/paymentrails/BatchSummary.rb
@@ -1,6 +1,19 @@
 module PaymentRails
   class BatchSummary
-    attr_accessor :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :methods, :detail, :total
-    attr_writer :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :methods, :detail, :total
+    attr_accessor(
+      :id,
+      :amount,
+      :completedAt,
+      :createdAt,
+      :currency,
+      :description,
+      :sentAt,
+      :status,
+      :totalPayments,
+      :updatedAt,
+      :methods,
+      :detail,
+      :total
+    )
   end
 end

--- a/lib/paymentrails/BatchSummary.rb
+++ b/lib/paymentrails/BatchSummary.rb
@@ -13,7 +13,8 @@ module PaymentRails
       :updatedAt,
       :methods,
       :detail,
-      :total
+      :total,
+      :balances
     )
   end
 end

--- a/lib/paymentrails/OfflinePayment.rb
+++ b/lib/paymentrails/OfflinePayment.rb
@@ -1,6 +1,23 @@
 module PaymentRails
   class OfflinePayment
-    attr_accessor :id, :recipientId, :externalId, :memo, :tags, :taxReportable, :category, :amount, :currency, :withholdingAmount, :withholdingCurrency, :processedAt, :equivalentWithholdingAmount, :equivalentWithholdingCurrency, :updatedAt, :createdAt, :deletedAt
-    attr_writer :id, :externalId, :memo, :tags, :taxReportable, :category, :amount, :currency, :withholdingAmount, :withholdingCurrency, :processedAt
+    attr_accessor(
+      :id,
+      :recipientId,
+      :externalId,
+      :memo,
+      :tags,
+      :taxReportable,
+      :category,
+      :amount,
+      :currency,
+      :withholdingAmount,
+      :withholdingCurrency,
+      :processedAt,
+      :equivalentWithholdingAmount,
+      :equivalentWithholdingCurrency,
+      :updatedAt,
+      :createdAt,
+      :deletedAt
+    )
   end
 end

--- a/lib/paymentrails/Payment.rb
+++ b/lib/paymentrails/Payment.rb
@@ -44,7 +44,8 @@ module PaymentRails
       :returnedNote,
       :returnedReason,
       :failureMessage,
-      :merchantId
+      :merchantId,
+      :checkNumber
     )
   end
 end

--- a/lib/paymentrails/Recipient.rb
+++ b/lib/paymentrails/Recipient.rb
@@ -1,6 +1,40 @@
 module PaymentRails
   class Recipient
-    attr_accessor :id, :routeType, :estimatedFees, :referenceId, :email, :name, :lastName, :firstName, :type, :taxType, :status, :language, :complianceStatus, :dob, :passport, :updatedAt, :createdAt, :gravatarUrl, :governmentId, :ssn, :primaryCurrency, :merchantId, :payout, :compliance, :accounts, :address, :taxWithholdingPercentage, :taxForm, :taxFormStatus, :inactiveReasons, :payoutMethod, :placeOfBirth, :tags, :taxDeliveryType
-    attr_writer :id, :routeType, :estimatedFees, :referenceId, :email, :name, :lastName, :firstName, :type, :taxType, :status, :language, :complianceStatus, :dob, :passport, :updatedAt, :createdAt, :gravatarUrl, :governmentId, :ssn, :primaryCurrency, :merchantId, :payout, :compliance, :accounts, :address, :taxWithholdingPercentage, :taxForm, :taxFormStatus, :inactiveReasons, :payoutMethod, :placeOfBirth, :tags, :taxDeliveryType
+    attr_accessor(
+      :id,
+      :routeType,
+      :estimatedFees,
+      :referenceId,
+      :email,
+      :name,
+      :lastName,
+      :firstName,
+      :type,
+      :taxType,
+      :status,
+      :language,
+      :complianceStatus,
+      :dob,
+      :passport,
+      :updatedAt,
+      :createdAt,
+      :gravatarUrl,
+      :governmentId,
+      :ssn,
+      :primaryCurrency,
+      :merchantId,
+      :payout,
+      :compliance,
+      :accounts,
+      :address,
+      :taxWithholdingPercentage,
+      :taxForm,
+      :taxFormStatus,
+      :inactiveReasons,
+      :payoutMethod,
+      :placeOfBirth,
+      :tags,
+      :taxDeliveryType
+    )
   end
 end

--- a/lib/paymentrails/Recipient.rb
+++ b/lib/paymentrails/Recipient.rb
@@ -34,7 +34,8 @@ module PaymentRails
       :payoutMethod,
       :placeOfBirth,
       :tags,
-      :taxDeliveryType
+      :taxDeliveryType,
+      :riskScore
     )
   end
 end

--- a/lib/paymentrails/RecipientAccount.rb
+++ b/lib/paymentrails/RecipientAccount.rb
@@ -1,6 +1,30 @@
 module PaymentRails
   class RecipientAccount
-    attr_accessor	:id, :primary, :currency, :recipientAccountId, :recipientId, :recipientReferenceId, :routeType, :recipientFees, :emailAddress, :country, :type, :iban, :accountNum, :accountHolderName, :swiftBic, :branchId, :bankId, :bankName, :bankAddress, :bankCity, :bankRegionCode, :bankPostalCode, :status, :disabledAt
-    attr_writer	:id, :primary, :currency, :recipientAccountId, :recipientId, :recipientReferenceId, :routeType, :recipientFees, :emailAddress, :country, :type, :iban, :accountNum, :accountHolderName, :swiftBic, :branchId, :bankId, :bankName, :bankAddress, :bankCity, :bankRegionCode, :bankPostalCode, :status, :disabledAt
+    attr_accessor(
+      :id,
+      :primary,
+      :currency,
+      :recipientAccountId,
+      :recipientId,
+      :recipientReferenceId,
+      :routeType,
+      :recipientFees,
+      :emailAddress,
+      :country,
+      :type,
+      :iban,
+      :accountNum,
+      :accountHolderName,
+      :swiftBic,
+      :branchId,
+      :bankId,
+      :bankName,
+      :bankAddress,
+      :bankCity,
+      :bankRegionCode,
+      :bankPostalCode,
+      :status,
+      :disabledAt
+    )
   end
 end

--- a/lib/paymentrails/gateways/BatchGateway.rb
+++ b/lib/paymentrails/gateways/BatchGateway.rb
@@ -1,7 +1,10 @@
 require_relative '../Client.rb'
+require_relative 'GatewayHelper'
 
 module PaymentRails
   class BatchGateway
+    include GatewayHelper
+
     def initialize(client)
       @client = client
     end
@@ -51,9 +54,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'batch'
-        value.each do |newKey, newValue|
-          batch.send("#{newKey}=", newValue)
-        end
+        loosely_hydrate_model(batch, value)
       end
       batch
     end
@@ -64,9 +65,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'batchSummary'
-        value.each do |newKey, newValue|
-          summary.send("#{newKey}=", newValue)
-        end
+        loosely_hydrate_model(summary, value)
       end
       summary
     end
@@ -78,11 +77,9 @@ module PaymentRails
       data.each do |key, value|
         next unless key === 'batches'
         value.each do |newKey, _newValue|
-          batch = Batch.new
-          newKey.each do |key1, value1|
-            batch.send("#{key1}=", value1)
-          end
-          batches.push(batch)
+          batches.push(
+            loosely_hydrate_model(Batch.new, newKey)
+          )
         end
       end
       batches

--- a/lib/paymentrails/gateways/GatewayHelper.rb
+++ b/lib/paymentrails/gateways/GatewayHelper.rb
@@ -1,0 +1,16 @@
+module PaymentRails
+  module GatewayHelper
+    def loosely_hydrate_model(klass_instance, attributes)
+      attributes.each do |k, v|
+        begin
+          klass_instance.send("#{k}=", v)
+        rescue NoMethodError
+          warn "[PaymentRails] Unknown attribute #{k} for class #{klass_instance.class.name}"
+        end
+      end
+
+      klass_instance
+    end
+  end
+end
+

--- a/lib/paymentrails/gateways/OfflinePaymentGateway.rb
+++ b/lib/paymentrails/gateways/OfflinePaymentGateway.rb
@@ -1,7 +1,10 @@
 require_relative '../Client.rb'
+require_relative 'GatewayHelper'
 
 module PaymentRails
   class OfflinePaymentGateway
+    include GatewayHelper
+
     def initialize(client)
       @client = client
     end
@@ -36,9 +39,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'offlinePayment'
-        value.each do |opKey, opValue|
-          offline_payment.send("#{opKey}=", opValue)
-        end
+        loosely_hydrate_model(offline_payment, value)
       end
       offline_payment
     end
@@ -50,10 +51,7 @@ module PaymentRails
       data.each do |key, value|
         next unless key === 'offlinePayments'
         value.each do |newKey, _newValue|
-          offline_payment = OfflinePayment.new
-          newKey.each do |key1, value1|
-            offline_payment.send("#{key1}=", value1)
-          end
+          offline_payment = loosely_hydrate_model(OfflinePayment.new, newKey)
           offline_payments.push(offline_payment)
         end
       end

--- a/lib/paymentrails/gateways/PaymentGateway.rb
+++ b/lib/paymentrails/gateways/PaymentGateway.rb
@@ -1,7 +1,10 @@
 require_relative '../Client.rb'
+require_relative 'GatewayHelper'
 
 module PaymentRails
   class PaymentGateway
+    include GatewayHelper
+
     def initialize(client)
       @client = client
     end
@@ -36,9 +39,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'payment'
-        value.each do |recipKey, recipValue|
-          payment.send("#{recipKey}=", recipValue)
-        end
+        loosely_hydrate_model(payment, value)
       end
       payment
     end
@@ -50,10 +51,7 @@ module PaymentRails
       data.each do |key, value|
         next unless key === 'payments'
         value.each do |newKey, _newValue|
-          payment = Payment.new
-          newKey.each do |key1, value1|
-            payment.send("#{key1}=", value1)
-          end
+          payment = loosely_hydrate_model(Payment.new, newKey)
           payments.push(payment)
         end
       end

--- a/lib/paymentrails/gateways/RecipientAccountGateway.rb
+++ b/lib/paymentrails/gateways/RecipientAccountGateway.rb
@@ -1,7 +1,10 @@
 require_relative '../Client.rb'
+require_relative 'GatewayHelper'
 
 module PaymentRails
   class RecipientAccountGateway
+    include GatewayHelper
+
     def initialize(client)
       @client = client
     end
@@ -36,9 +39,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'account'
-        value.each do |recipKey, recipValue|
-          recipient_account.send("#{recipKey}=", recipValue)
-        end
+        loosely_hydrate_model(recipient_account, value)
       end
       recipient_account
     end
@@ -50,10 +51,7 @@ module PaymentRails
       data.each do |key, value|
         next unless key === 'accounts'
         value.each do |newKey, _newValue|
-          recipient_account = RecipientAccount.new
-          newKey.each do |key1, value1|
-            recipient_account.send("#{key1}=", value1)
-          end
+          recipient_account = loosely_hydrate_model(RecipientAccount.new, newKey)
           recipient_accounts.push(recipient_account)
         end
       end

--- a/lib/paymentrails/gateways/RecipientGateway.rb
+++ b/lib/paymentrails/gateways/RecipientGateway.rb
@@ -1,7 +1,10 @@
 require_relative '../Client.rb'
+require_relative 'GatewayHelper'
 
 module PaymentRails
   class RecipientGateway
+    include GatewayHelper
+
     def initialize(client)
       @client = client
     end
@@ -36,9 +39,7 @@ module PaymentRails
       data = JSON.parse(response)
       data.each do |key, value|
         next unless key === 'recipient'
-        value.each do |recipKey, recipValue|
-          recipient.send("#{recipKey}=", recipValue)
-        end
+        loosely_hydrate_model(recipient, value)
       end
       recipient
     end
@@ -50,10 +51,7 @@ module PaymentRails
       data.each do |key, value|
         next unless key === 'recipients'
         value.each do |newKey, _newValue|
-          recipient = Recipient.new
-          newKey.each do |key1, value1|
-            recipient.send("#{key1}=", value1)
-          end
+          recipient = loosely_hydrate_model(Recipient.new, newKey)
           recipients.push(recipient)
         end
       end

--- a/paymentrails.gemspec
+++ b/paymentrails.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
   s.add_development_dependency 'dotenv', '~> 2'
   s.add_development_dependency 'rake', '~> 12'
-  s.add_development_dependency "rubocop", '~> 0.77'
+  s.add_development_dependency "rubocop", '~> 0.77.0'
   s.add_development_dependency 'test-unit', '~> 3'
 end


### PR DESCRIPTION
```ruby
vendor/bundle/ruby/2.4.0/bundler/gems/ruby-sdk-43b264cdb08d/lib/paymentrails/gateways/RecipientGateway.rb:40:in `block (2 levels) in recipient_builder': undefined method `riskScore=' for #<PaymentRails::Recipient:0x000000000f88dfd8> (ActionView::Template::Error)
    from vendor/bundle/ruby/2.4.0/bundler/gems/ruby-sdk-43b264cdb08d/lib/paymentrails/gateways/RecipientGateway.rb:39:in `each'
```
1. Reorganize all the setters to be readable
2. Add the `riskScore=` setter
3. ~Jeez I should really get rid of that whole setter pattern~ Addressed that

Discovered more missing methods similar to #30 using the integration specs I wrote in #28 
`bundle exec rake integration_tests` to find them
```
Loaded suite /Users/maxschwenk/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader
Started
[PaymentRails] Unknown attribute checkNumber for class PaymentRails::Payment
[PaymentRails] Unknown attribute balances for class PaymentRails::BatchSummary
```