### PR TITLE
add missing riskScore, checkNumber, balances attrs

### DIFF
--- a/lib/paymentrails/Batch.rb
+++ b/lib/paymentrails/Batch.rb
@@ -1,6 +1,5 @@
 module PaymentRails
   class Batch
     attr_accessor	:id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :quoteExpiredAt, :payments, :tags, :coverFees
-    attr_writer :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :quoteExpiredAt, :payments, :tags, :coverFees
   end
 end

--- a/lib/paymentrails/BatchSummary.rb
+++ b/lib/paymentrails/BatchSummary.rb
@@ -1,6 +1,5 @@
 module PaymentRails
   class BatchSummary
-    attr_accessor :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :methods, :detail, :total
-    attr_writer :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :methods, :detail, :total
+    attr_accessor :id, :amount, :completedAt, :createdAt, :currency, :description, :sentAt, :status, :totalPayments, :updatedAt, :methods, :detail, :total, :balances
   end
 end

--- a/lib/paymentrails/Gateway.rb
+++ b/lib/paymentrails/Gateway.rb
@@ -1,28 +1,7 @@
 module PaymentRails
   class Gateway
-    attr_reader :config
-    attr_writer :config
 
-    attr_reader :client
-    attr_writer :client
-
-    attr_reader :recipient
-    attr_writer :recipient
-
-    attr_reader :recipient_account
-    attr_writer :recipient_account
-
-    attr_reader :batch
-    attr_writer :batch
-
-    attr_reader :payment
-    attr_writer :payment
-
-    attr_reader :balance
-    attr_writer :balance
-
-    attr_reader :offline_payment
-    attr_writer :offline_payment
+    attr_accessor :config, :client, :recipient, :recipient_account, :batch, :payment, :balance, :offline_payment
 
     def initialize(config)
       @config = config

--- a/lib/paymentrails/OfflinePayment.rb
+++ b/lib/paymentrails/OfflinePayment.rb
@@ -1,6 +1,5 @@
 module PaymentRails
   class OfflinePayment
     attr_accessor :id, :recipientId, :externalId, :memo, :tags, :taxReportable, :category, :amount, :currency, :withholdingAmount, :withholdingCurrency, :processedAt, :equivalentWithholdingAmount, :equivalentWithholdingCurrency, :updatedAt, :createdAt, :deletedAt
-    attr_writer :id, :externalId, :memo, :tags, :taxReportable, :category, :amount, :currency, :withholdingAmount, :withholdingCurrency, :processedAt
   end
 end

--- a/lib/paymentrails/Payment.rb
+++ b/lib/paymentrails/Payment.rb
@@ -44,7 +44,8 @@ module PaymentRails
       :returnedNote,
       :returnedReason,
       :failureMessage,
-      :merchantId
+      :merchantId,
+      :checkNumber
     )
   end
 end

--- a/lib/paymentrails/Recipient.rb
+++ b/lib/paymentrails/Recipient.rb
@@ -1,6 +1,5 @@
 module PaymentRails
   class Recipient
-    attr_accessor :id, :routeType, :estimatedFees, :referenceId, :email, :name, :lastName, :firstName, :type, :taxType, :status, :language, :complianceStatus, :dob, :passport, :updatedAt, :createdAt, :gravatarUrl, :governmentId, :ssn, :primaryCurrency, :merchantId, :payout, :compliance, :accounts, :address, :taxWithholdingPercentage, :taxForm, :taxFormStatus, :inactiveReasons, :payoutMethod, :placeOfBirth, :tags, :taxDeliveryType
-    attr_writer :id, :routeType, :estimatedFees, :referenceId, :email, :name, :lastName, :firstName, :type, :taxType, :status, :language, :complianceStatus, :dob, :passport, :updatedAt, :createdAt, :gravatarUrl, :governmentId, :ssn, :primaryCurrency, :merchantId, :payout, :compliance, :accounts, :address, :taxWithholdingPercentage, :taxForm, :taxFormStatus, :inactiveReasons, :payoutMethod, :placeOfBirth, :tags, :taxDeliveryType
+    attr_accessor :id, :routeType, :estimatedFees, :referenceId, :email, :name, :lastName, :firstName, :type, :taxType, :status, :language, :complianceStatus, :dob, :passport, :updatedAt, :createdAt, :gravatarUrl, :governmentId, :ssn, :primaryCurrency, :merchantId, :payout, :compliance, :accounts, :address, :taxWithholdingPercentage, :taxForm, :taxFormStatus, :inactiveReasons, :payoutMethod, :placeOfBirth, :tags, :taxDeliveryType, :riskScore
   end
 end

--- a/lib/paymentrails/RecipientAccount.rb
+++ b/lib/paymentrails/RecipientAccount.rb
@@ -1,6 +1,5 @@
 module PaymentRails
   class RecipientAccount
     attr_accessor	:id, :primary, :currency, :recipientAccountId, :recipientId, :recipientReferenceId, :routeType, :recipientFees, :emailAddress, :country, :type, :iban, :accountNum, :accountHolderName, :swiftBic, :branchId, :bankId, :bankName, :bankAddress, :bankCity, :bankRegionCode, :bankPostalCode, :status, :disabledAt
-    attr_writer	:id, :primary, :currency, :recipientAccountId, :recipientId, :recipientReferenceId, :routeType, :recipientFees, :emailAddress, :country, :type, :iban, :accountNum, :accountHolderName, :swiftBic, :branchId, :bankId, :bankName, :bankAddress, :bankCity, :bankRegionCode, :bankPostalCode, :status, :disabledAt
   end
 end


### PR DESCRIPTION
This missing fields were causing tests to fail. some other assorted `attr_*` cleanup as well that removed warnings.