### PR TITLE
🐛  Fix two typos in error handlers; fixup Rubocop version

### DIFF
--- a/lib/paymentrails/Client.rb
+++ b/lib/paymentrails/Client.rb
@@ -83,7 +83,7 @@ module PaymentRails
         when '404'
           raise NotFoundError, message
         when '429'
-          raise TooManyRequestsError message
+          raise TooManyRequestsError, message
         when '500'
           raise ServerError, message
         when '503'

--- a/lib/paymentrails/Client.rb
+++ b/lib/paymentrails/Client.rb
@@ -79,7 +79,7 @@ module PaymentRails
         when '401'
           raise AuthenticationError, message
         when '403'
-          raise AuthorizationErrormessage
+          raise AuthorizationError, message
         when '404'
           raise NotFoundError, message
         when '429'

--- a/paymentrails.gemspec
+++ b/paymentrails.gemspec
@@ -13,6 +13,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
   s.add_development_dependency 'dotenv', '~> 2'
   s.add_development_dependency 'rake', '~> 12'
-  s.add_development_dependency "rubocop", '~> 0.77'
+  s.add_development_dependency "rubocop", '~> 0.77.0'
   s.add_development_dependency 'test-unit', '~> 3'
 end


### PR DESCRIPTION
1. Fix two typos in error handlers
1. Fix incorrect version pinning for Rubocop (because it was `0.77` would be resolved to anything within same minor version, i.e. 0.x.y)