### PR TITLE
Add additional attributes to Recipient, BatchSummary, and Payment

### DIFF
--- a/lib/paymentrails/BatchSummary.rb
+++ b/lib/paymentrails/BatchSummary.rb
@@ -14,7 +14,8 @@ module PaymentRails
       :methods,
       :detail,
       :total,
-      :balances
+      :balances,
+      :accounts
     )
   end
 end

--- a/lib/paymentrails/Payment.rb
+++ b/lib/paymentrails/Payment.rb
@@ -45,7 +45,8 @@ module PaymentRails
       :returnedReason,
       :failureMessage,
       :merchantId,
-      :checkNumber
+      :checkNumber,
+      :forceUsTaxActivity
     )
   end
 end

--- a/lib/paymentrails/Recipient.rb
+++ b/lib/paymentrails/Recipient.rb
@@ -35,7 +35,8 @@ module PaymentRails
       :placeOfBirth,
       :tags,
       :taxDeliveryType,
-      :riskScore
+      :riskScore,
+      :isPortalUser
     )
   end
 end


### PR DESCRIPTION
We are seeing the following warning every time we pull recipients or batch summaries from the Payment Rails API.

```
[PaymentRails] Unknown attribute isPortalUser for class PaymentRails::Recipient
```

This PR adds:
- `isPortalUser` attribute to the `PaymentRails::Recipient` model
- `accounts` attribute to the `PaymentRails::BatchSummary` model
- `forceUsTaxActivity` attribute to the `PaymentRails::Payment` model