### PR TITLE
[Fix] Attempt to fixup CI failure fetching ruby 2.7.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1.71.0
-#       with:
-#         ruby-version: 2.4.x
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
     - name: Build and run Rubocop
       run: |
         gem install bundler


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes

CI in mainline branch is failing after upping ruby version
![image](https://user-images.githubusercontent.com/101163238/190866032-71cc383f-9d36-4497-b3fc-84c21b5a32bd.png)

[link](https://github.com/PaymentRails/ruby-sdk/actions/runs/3073829502/jobs/4966215658)

Apparently this comes from a GH actions misconfiguration, check comment below!

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
