### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/.cursor/rules/cloud-agent.mdc
+++ b/.cursor/rules/cloud-agent.mdc
@@ -1,0 +1,12 @@
+---
+description: Cursor Cloud Agent environment details for Trolley Ruby SDK
+globs:
+alwaysApply: true
+---
+
+# Cloud Agent environment
+
+- Ruby 3.2.2 is installed at `/usr/local/bin/ruby`.
+- Sandbox API credentials are available as env vars `SANDBOX_API_KEY` and `SANDBOX_SECRET_KEY` (injected via Cursor Secrets).
+- Write them to `.env` before running live integration tests: `cp .env.template .env` then replace the fake values with `$SANDBOX_API_KEY` / `$SANDBOX_SECRET_KEY`.
+- VCR cassette playback works with fake keys — no secrets needed for `bundle exec rake`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,29 @@
-## Cursor Cloud specific instructions
+# AGENTS.md
 
-This is the **Trolley Ruby SDK** — a Ruby gem wrapping the Trolley payments API. No databases or background services are required.
+Ruby SDK for the [Trolley](https://trolley.com) payments API. Pure gem — no databases or background services.
 
-### Quick reference
+## Development
 
-| Task | Command |
-|---|---|
-| Install deps | `bundle install` |
-| Lint | `bundle exec rubocop` |
-| Unit tests | `bundle exec rake unit_tests` |
-| Integration tests | `bundle exec rake integration_tests` |
-| All tests | `bundle exec rake` |
-| Build gem | `gem build trolley.gemspec` |
+Requires Ruby 3.2.2 (see `.ruby-version`). Setup and test commands are in `CONTRIBUTING.md`. Quick reference:
 
-### API keys
+```
+bundle install                        # install deps
+bundle exec rubocop                   # lint
+bundle exec rake unit_tests           # unit tests only
+bundle exec rake integration_tests    # integration tests only
+bundle exec rake                      # all tests
+gem build trolley.gemspec             # build gem
+```
 
-Sandbox credentials go in `.env` (loaded by `dotenv`). The file has two required variables:
+## Testing without API keys
+
+Integration tests use VCR cassettes (`test/fixtures/`). Copy `.env.template` to `.env` — the fake keys are sufficient for cassette playback. No live API access is needed to run the full test suite.
+
+## Testing with live API
+
+To re-record cassettes or test against the sandbox, add real credentials from [developers.trolley.com](https://developers.trolley.com) to `.env`:
 
 ```
 SANDBOX_API_KEY=<your access key>
 SANDBOX_SECRET_KEY=<your secret key>
 ```
-
-Get sandbox keys from [developers.trolley.com](https://developers.trolley.com). In Cloud Agent environments these are injected as env vars via Cursor Secrets (`SANDBOX_API_KEY`, `SANDBOX_SECRET_KEY`).
-
-### Important notes
-
-- Ruby 3.2.2 is required (see `.ruby-version`). It is installed at `/usr/local/bin/ruby`.
-- Integration tests use VCR cassettes in `test/fixtures/` and do **not** need live API credentials. The `.env` file with fake keys (copied from `.env.template`) is sufficient for cassette playback.
-- To re-record VCR cassettes or run live integration tests, set real `SANDBOX_API_KEY` and `SANDBOX_SECRET_KEY` in `.env`. See `CONTRIBUTING.md`.
-- The gem has no runtime dependencies; all deps in the gemspec are `add_development_dependency`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+## Cursor Cloud specific instructions
+
+This is the **Trolley Ruby SDK** — a Ruby gem wrapping the Trolley payments API. No databases or background services are required.
+
+### Quick reference
+
+| Task | Command |
+|---|---|
+| Install deps | `bundle install` |
+| Lint | `bundle exec rubocop` |
+| Unit tests | `bundle exec rake unit_tests` |
+| Integration tests | `bundle exec rake integration_tests` |
+| All tests | `bundle exec rake` |
+| Build gem | `gem build trolley.gemspec` |
+
+### Important notes
+
+- Ruby 3.2.2 is required (see `.ruby-version`). It is installed at `/usr/local/bin/ruby`.
+- Integration tests use VCR cassettes in `test/fixtures/` and do **not** need live API credentials. The `.env` file with fake keys (copied from `.env.template`) is sufficient for cassette playback.
+- To re-record VCR cassettes or run live integration tests, set real `SANDBOX_API_KEY` and `SANDBOX_SECRET_KEY` in `.env`. See `CONTRIBUTING.md`.
+- The gem has no runtime dependencies; all deps in the gemspec are `add_development_dependency`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,17 @@ This is the **Trolley Ruby SDK** — a Ruby gem wrapping the Trolley payments AP
 | All tests | `bundle exec rake` |
 | Build gem | `gem build trolley.gemspec` |
 
+### API keys
+
+Sandbox credentials go in `.env` (loaded by `dotenv`). The file has two required variables:
+
+```
+SANDBOX_API_KEY=<your access key>
+SANDBOX_SECRET_KEY=<your secret key>
+```
+
+Get sandbox keys from [developers.trolley.com](https://developers.trolley.com). In Cloud Agent environments these are injected as env vars via Cursor Secrets (`SANDBOX_API_KEY`, `SANDBOX_SECRET_KEY`).
+
 ### Important notes
 
 - Ruby 3.2.2 is required (see `.ruby-version`). It is installed at `/usr/local/bin/ruby`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     ast (2.4.2)
     crack (0.4.5)
       rexml
+    docile (1.4.1)
     dotenv (2.8.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -36,6 +37,12 @@ GEM
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     test-unit (3.5.7)
       power_assert
     unicode-display_width (2.4.2)
@@ -52,6 +59,7 @@ DEPENDENCIES
   dotenv (~> 2)
   rake (~> 13)
   rubocop (~> 1)
+  simplecov (~> 0.22)
   test-unit (~> 3)
   trolley!
   vcr (~> 6.2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds AI assistant development context and updates `Gemfile.lock` to include declared-but-missing `simplecov` dependencies.

### Changes
- **`AGENTS.md`** — Environment-agnostic development guide usable by any AI assistant: command reference, testing with/without live API keys
- **`.cursor/rules/cloud-agent.mdc`** — Cursor-specific Cloud Agent details: Ruby install path, secret names, `.env` setup
- **`Gemfile.lock`** — Added `simplecov`, `docile`, `simplecov-html`, `simplecov_json_formatter` (declared in gemspec but previously missing from lockfile)

### Verification

- `bundle exec rubocop` — 40 files, 0 offenses
- `bundle exec rake` — 48 tests, 204 assertions, 100% passed, 96.26% line coverage
- `gem build trolley.gemspec` — builds successfully
- Live sandbox hello world — created/fetched/deleted recipient against sandbox API

[hello_world_live.log](https://cursor.com/agents/bc-f9e59eaa-82fb-47ed-ad07-0dec12eb7b74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_live.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9e59eaa-82fb-47ed-ad07-0dec12eb7b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9e59eaa-82fb-47ed-ad07-0dec12eb7b74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

