### PR TITLE
feat(ruby-sdk): add generic request entrypoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     ast (2.4.2)
     crack (0.4.5)
       rexml
+    docile (1.4.1)
     dotenv (2.8.1)
     hashdiff (1.0.1)
     json (2.6.3)
@@ -36,6 +37,12 @@ GEM
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     test-unit (3.5.7)
       power_assert
     unicode-display_width (2.4.2)
@@ -46,12 +53,14 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES
   dotenv (~> 2)
   rake (~> 13)
   rubocop (~> 1)
+  simplecov (~> 0.22)
   test-unit (~> 3)
   trolley!
   vcr (~> 6.2)

--- a/lib/trolley.rb
+++ b/lib/trolley.rb
@@ -9,6 +9,7 @@ require 'trolley/gateways/RecipientAccountGateway'
 require 'trolley/gateways/OfflinePaymentGateway'
 require 'trolley/gateways/InvoiceGateway'
 require 'trolley/gateways/InvoicePaymentGateway'
+require 'trolley/gateways/VerificationGateway'
 
 require 'trolley/utils/PaginatedArray'
 require 'trolley/utils/ResponseMapper'

--- a/lib/trolley/Client.rb
+++ b/lib/trolley/Client.rb
@@ -31,6 +31,11 @@ module Trolley
       send_request(endPoint, 'PATCH', body)
     end
 
+    def request(method, endPoint, body = nil)
+      payload = body.nil? || body.is_a?(String) ? body.to_s : body.to_json
+      send_request(endPoint, method.to_s.upcase, payload)
+    end
+
     private
 
     # rubocop:disable Metrics/CyclomaticComplexity
@@ -64,7 +69,7 @@ module Trolley
 
       response = http.request(request)
 
-      if response.code != '200' && response.code != '204'
+      unless response.code.to_i.between?(200, 299)
         throw_status_code_exception("#{response.message} #{response.body}" , response.code, response.body)
       end
       response.body

--- a/lib/trolley/Gateway.rb
+++ b/lib/trolley/Gateway.rb
@@ -14,5 +14,9 @@ module Trolley
       @invoice = InvoiceGateway.new(client)
       @invoice_payment = InvoicePaymentGateway.new(client)
     end
+
+    def request(method, end_point, body = nil)
+      @client.request(method, end_point, body)
+    end
   end
 end

--- a/lib/trolley/Gateway.rb
+++ b/lib/trolley/Gateway.rb
@@ -1,6 +1,6 @@
 module Trolley
   class Gateway
-    attr_accessor :config, :client, :recipient, :recipient_account, :batch, :payment, :balance, :offline_payment, :invoice, :invoice_payment
+    attr_accessor :config, :client, :recipient, :recipient_account, :batch, :payment, :balance, :offline_payment, :invoice, :invoice_payment, :verification, :trust
 
     def initialize(config)
       @config = config
@@ -13,6 +13,8 @@ module Trolley
       @offline_payment = OfflinePaymentGateway.new(client)
       @invoice = InvoiceGateway.new(client)
       @invoice_payment = InvoicePaymentGateway.new(client)
+      @verification = VerificationGateway.new(client)
+      @trust = @verification
     end
 
     def request(method, end_point, body = nil)

--- a/lib/trolley/InvoicePayment.rb
+++ b/lib/trolley/InvoicePayment.rb
@@ -7,7 +7,12 @@ module Trolley
       :invoiceId,
       :invoiceLineId,
       :amount,
-      :invoicePayments
+      :invoicePayments,
+      :status,
+      :memo,
+      :externalId,
+      :tags,
+      :coverFees
     )
   end
 end

--- a/lib/trolley/OfflinePayment.rb
+++ b/lib/trolley/OfflinePayment.rb
@@ -17,7 +17,8 @@ module Trolley
       :equivalentWithholdingCurrency,
       :updatedAt,
       :createdAt,
-      :deletedAt
+      :deletedAt,
+      :activityCount
     )
   end
 end

--- a/lib/trolley/Payment.rb
+++ b/lib/trolley/Payment.rb
@@ -7,8 +7,10 @@ module Trolley
       :returnedAmount,
       :sourceAmount,
       :sourceCurrency,
+      :sourceCurrencyName,
       :targetAmount,
       :targetCurrency,
+      :targetCurrencyName,
       :exchangeRate,
       :fees,
       :recipientFees,
@@ -46,7 +48,8 @@ module Trolley
       :failureMessage,
       :merchantId,
       :checkNumber,
-      :forceUsTaxActivity
+      :forceUsTaxActivity,
+      :visibleToRecipient
     )
   end
 end

--- a/lib/trolley/RecipientAccount.rb
+++ b/lib/trolley/RecipientAccount.rb
@@ -24,7 +24,10 @@ module Trolley
       :bankRegionCode,
       :bankPostalCode,
       :status,
-      :disabledAt
+      :disabledAt,
+      :cardDetails,
+      :mailing,
+      :phoneNumber
     )
   end
 end

--- a/lib/trolley/gateways/BalanceGateway.rb
+++ b/lib/trolley/gateways/BalanceGateway.rb
@@ -8,7 +8,7 @@ module Trolley
     end
 
     def find(term = '')
-      path = term.to_s.empty? ? '/v1/balances' : "/v1/balances/#{term}"
+      path = term.to_s.empty? ? '/v1/balances/' : "/v1/balances/#{term}"
       response = @client.get(path)
       JSON.parse(response,  object_class: OpenStruct)
     end

--- a/lib/trolley/gateways/BalanceGateway.rb
+++ b/lib/trolley/gateways/BalanceGateway.rb
@@ -1,4 +1,5 @@
 require_relative '../Client'
+require 'ostruct'
 
 module Trolley
   class BalanceGateway
@@ -7,9 +8,25 @@ module Trolley
     end
 
     def find(term = '')
-      response = @client.get("/v1/balances/#{term}" )
+      path = term.to_s.empty? ? '/v1/balances' : "/v1/balances/#{term}"
+      response = @client.get(path)
       JSON.parse(response,  object_class: OpenStruct)
     end
 
+    def all
+      balance_builder(@client.get('/v1/balances'))
+    end
+
+    def paymentrails
+      balance_builder(@client.get('/v1/balances/paymentrails'))
+    end
+
+    def paypal
+      balance_builder(@client.get('/v1/balances/paypal'))
+    end
+
+    def balance_builder(response)
+      JSON.parse(response, object_class: OpenStruct)
+    end
   end
 end

--- a/lib/trolley/gateways/PaymentGateway.rb
+++ b/lib/trolley/gateways/PaymentGateway.rb
@@ -11,6 +11,11 @@ module Trolley
       payment_builder(response)
     end
 
+    def find_by_id(payment_id)
+      response = @client.get("/v1/payments/#{payment_id}")
+      payment_builder(response)
+    end
+
     def create(batch_id, body)
       response = @client.post("/v1/batches/#{batch_id}/payments", body)
       payment_builder(response)

--- a/lib/trolley/gateways/VerificationGateway.rb
+++ b/lib/trolley/gateways/VerificationGateway.rb
@@ -1,0 +1,40 @@
+require_relative '../Client'
+require 'json'
+require 'ostruct'
+require 'uri'
+
+module Trolley
+  class VerificationGateway
+    def initialize(client)
+      @client = client
+    end
+
+    def search(filters = {})
+      path = '/v1/verifications'
+      query_string = URI.encode_www_form(filters)
+      path = "#{path}?#{query_string}" unless query_string.empty?
+
+      verification_list_builder(@client.get(path))
+    end
+
+    alias all search
+
+    def expire(body)
+      verification_list_builder(@client.patch('/v1/verifications/expire', body))
+    end
+
+    def trigger(verification_type, body)
+      verification_list_builder(@client.post("/v1/verifications/#{verification_type}/trigger", body))
+    end
+
+    def trigger_watchlist(body)
+      verification_list_builder(@client.post('/v1/verifications/watchlist/trigger', body))
+    end
+
+    private
+
+    def verification_list_builder(response)
+      JSON.parse(response, object_class: OpenStruct)
+    end
+  end
+end

--- a/test/unit/ClientRequestTest.rb
+++ b/test/unit/ClientRequestTest.rb
@@ -1,0 +1,54 @@
+require_relative '../../lib/trolley'
+require 'test/unit'
+require 'webmock/test_unit'
+
+class ClientRequestTest < Test::Unit::TestCase
+  def setup
+    @config = Trolley::Configuration.new('key', 'secret', api_base: 'http://api.local.dev:3000')
+    @client = Trolley::Client.new(@config)
+  end
+
+  def test_request_posts_json_body_with_signed_headers
+    stub_request(:post, 'http://api.local.dev:3000/v1/recipients')
+      .with(
+        body: '{"type":"individual"}',
+        headers: {
+          'Authorization' => /^prsign key:/,
+          'Content-Type' => 'application/json',
+          'Trolley-Source' => "ruby-sdk_#{Trolley::VERSION}"
+        }
+      )
+      .to_return(status: 201, body: '{"ok":true}')
+
+    response = @client.request('POST', '/v1/recipients', type: 'individual')
+
+    assert_equal '{"ok":true}', response
+    assert_requested :post, 'http://api.local.dev:3000/v1/recipients'
+  end
+
+  def test_request_delete_supports_json_body
+    stub_request(:delete, 'http://api.local.dev:3000/v1/recipients')
+      .with(body: '{"ids":["R-123"]}')
+      .to_return(status: 200, body: '{"ok":true}')
+
+    @client.request('DELETE', '/v1/recipients', ids: ['R-123'])
+
+    assert_requested :delete, 'http://api.local.dev:3000/v1/recipients'
+  end
+
+  def test_request_accepts_204_response
+    stub_request(:delete, 'http://api.local.dev:3000/v1/recipients/R-123')
+      .to_return(status: 204, body: '')
+
+    assert_nil @client.request('DELETE', '/v1/recipients/R-123')
+  end
+
+  def test_gateway_exposes_request_without_changing_existing_accessors
+    gateway = Trolley.client('key', 'secret', api_base: 'http://api.local.dev:3000')
+
+    assert_respond_to gateway, :request
+    assert_respond_to gateway, :recipient
+    assert_respond_to gateway, :batch
+    assert_respond_to gateway, :invoice
+  end
+end

--- a/test/unit/GatewayParityTest.rb
+++ b/test/unit/GatewayParityTest.rb
@@ -90,6 +90,20 @@ class GatewayParityTest < Test::Unit::TestCase
     assert_equal 'P-123', @gateway.payment.create('B-123', payment_body).id
   end
 
+  def test_invoice_payment_response_fields_are_mapped
+    stub_request(:post, "#{API_BASE}/v1/invoices/payment/search")
+      .with(body: '{"invoiceIds":["I-123"]}')
+      .to_return(status: 200, body: invoice_payment_search_response)
+
+    invoice_payment = @gateway.invoice_payment.search(invoiceIds: ['I-123']).first
+
+    assert_equal 'pending', invoice_payment.status
+    assert_equal 'payment memo', invoice_payment.memo
+    assert_equal 'payment-external-id_123', invoice_payment.externalId
+    assert_equal ['invoice_payment', 'royalty invoice'], invoice_payment.tags
+    assert_equal true, invoice_payment.coverFees
+  end
+
   def test_gateway_exposes_verification_and_trust_aliases
     assert_same @gateway.verification, @gateway.trust
   end
@@ -98,5 +112,9 @@ class GatewayParityTest < Test::Unit::TestCase
 
   def verification_response
     '{"ok":true,"verifications":[{"id":"WV-123","type":"watchlist"}],"meta":{"page":1,"pages":1,"records":1}}'
+  end
+
+  def invoice_payment_search_response
+    '{"ok":true,"invoicePayments":[{"invoiceId":"I-123","invoiceLineId":"IL-123","paymentId":"P-123","amount":{"value":"150.00","currency":"EUR"},"status":"pending","memo":"payment memo","externalId":"payment-external-id_123","tags":["invoice_payment","royalty invoice"],"coverFees":true}]}'
   end
 end

--- a/test/unit/GatewayParityTest.rb
+++ b/test/unit/GatewayParityTest.rb
@@ -1,0 +1,102 @@
+require_relative '../../lib/trolley'
+require 'test/unit'
+require 'webmock/test_unit'
+
+class GatewayParityTest < Test::Unit::TestCase
+  API_BASE = 'http://api.local.dev:3000'.freeze
+
+  def setup
+    @gateway = Trolley.client('key', 'secret', api_base: API_BASE)
+  end
+
+  def test_balance_aliases_call_documented_endpoints
+    stub_request(:get, "#{API_BASE}/v1/balances").to_return(status: 200, body: '{"ok":true}')
+    stub_request(:get, "#{API_BASE}/v1/balances/paymentrails").to_return(status: 200, body: '{"ok":true}')
+    stub_request(:get, "#{API_BASE}/v1/balances/paypal").to_return(status: 200, body: '{"ok":true}')
+
+    assert_equal true, @gateway.balance.all.ok
+    assert_equal true, @gateway.balance.paymentrails.ok
+    assert_equal true, @gateway.balance.paypal.ok
+  end
+
+  def test_payment_find_by_id_calls_top_level_payment_endpoint
+    stub_request(:get, "#{API_BASE}/v1/payments/P-123")
+      .to_return(status: 200, body: '{"payment":{"id":"P-123"}}')
+
+    payment = @gateway.payment.find_by_id('P-123')
+
+    assert_equal 'P-123', payment.id
+  end
+
+  def test_verification_gateway_calls_documented_trust_endpoints
+    stub_request(:get, "#{API_BASE}/v1/verifications?verificationType=watchlist&page=1&pageSize=10")
+      .to_return(status: 200, body: verification_response)
+    stub_request(:patch, "#{API_BASE}/v1/verifications/expire")
+      .with(body: '{"type":"individual","verificationIds":["IV-123"]}')
+      .to_return(status: 200, body: verification_response)
+    stub_request(:post, "#{API_BASE}/v1/verifications/watchlist/trigger")
+      .with(body: '{"recipientIds":["R-123"]}')
+      .to_return(status: 200, body: verification_response)
+    stub_request(:post, "#{API_BASE}/v1/verifications/individual/trigger")
+      .with(body: '{"recipientIds":["R-123"]}')
+      .to_return(status: 200, body: verification_response)
+
+    assert_equal 'WV-123', @gateway.verification.search(verificationType: 'watchlist', page: 1, pageSize: 10).verifications.first.id
+    assert_equal 'WV-123', @gateway.verification.expire(type: 'individual', verificationIds: ['IV-123']).verifications.first.id
+    assert_equal 'WV-123', @gateway.verification.trigger_watchlist(recipientIds: ['R-123']).verifications.first.id
+    assert_equal 'WV-123', @gateway.trust.trigger('individual', recipientIds: ['R-123']).verifications.first.id
+  end
+
+  def test_existing_deletes_support_single_and_multiple_ids
+    stub_request(:delete, "#{API_BASE}/v1/batches/B-123").to_return(status: 200, body: '{"ok":true}')
+    stub_request(:delete, "#{API_BASE}/v1/batches/")
+      .with(body: '{"ids":["B-123","B-456"]}')
+      .to_return(status: 200, body: '{"ok":true}')
+    stub_request(:delete, "#{API_BASE}/v1/recipients/R-123").to_return(status: 200, body: '{"ok":true}')
+    stub_request(:delete, "#{API_BASE}/v1/recipients/")
+      .with(body: '{"ids":["R-123","R-456"]}')
+      .to_return(status: 200, body: '{"ok":true}')
+
+    assert_equal true, @gateway.batch.delete('B-123')
+    assert_equal true, @gateway.batch.delete(%w[B-123 B-456])
+    assert_equal true, @gateway.recipient.delete('R-123')
+    assert_equal true, @gateway.recipient.delete(%w[R-123 R-456])
+  end
+
+  def test_documented_body_fields_pass_through
+    recipient_body = {
+      referenceId: 'ref-123',
+      type: 'individual',
+      firstName: 'Ada',
+      governmentIds: [{ type: 'ssn', value: '1234' }],
+      tags: ['new']
+    }
+    stub_request(:post, "#{API_BASE}/v1/recipients/")
+      .with(body: recipient_body.to_json)
+      .to_return(status: 200, body: '{"recipient":{"id":"R-123"}}')
+
+    payment_body = {
+      recipient: { id: 'R-123' },
+      amount: '10.00',
+      currency: 'USD',
+      tags: ['docs'],
+      forceUsTaxActivity: true
+    }
+    stub_request(:post, "#{API_BASE}/v1/batches/B-123/payments")
+      .with(body: payment_body.to_json)
+      .to_return(status: 200, body: '{"payment":{"id":"P-123"}}')
+
+    assert_equal 'R-123', @gateway.recipient.create(recipient_body).id
+    assert_equal 'P-123', @gateway.payment.create('B-123', payment_body).id
+  end
+
+  def test_gateway_exposes_verification_and_trust_aliases
+    assert_same @gateway.verification, @gateway.trust
+  end
+
+  private
+
+  def verification_response
+    '{"ok":true,"verifications":[{"id":"WV-123","type":"watchlist"}],"meta":{"page":1,"pages":1,"records":1}}'
+  end
+end

--- a/test/unit/GatewayParityTest.rb
+++ b/test/unit/GatewayParityTest.rb
@@ -104,6 +104,37 @@ class GatewayParityTest < Test::Unit::TestCase
     assert_equal true, invoice_payment.coverFees
   end
 
+  def test_payment_response_fields_are_mapped
+    stub_request(:get, "#{API_BASE}/v1/payments/P-123")
+      .to_return(status: 200, body: payment_response)
+
+    payment = @gateway.payment.find_by_id('P-123')
+
+    assert_equal 'US Dollar', payment.sourceCurrencyName
+    assert_equal 'Canadian Dollar', payment.targetCurrencyName
+    assert_equal false, payment.visibleToRecipient
+  end
+
+  def test_offline_payment_response_fields_are_mapped
+    stub_request(:get, "#{API_BASE}/v1/offline-payments?page=1&pageSize=10&search=")
+      .to_return(status: 200, body: offline_payments_response)
+
+    offline_payment = @gateway.offline_payment.search.first
+
+    assert_equal 2, offline_payment.activityCount
+  end
+
+  def test_recipient_account_response_fields_are_mapped
+    stub_request(:get, "#{API_BASE}/v1/recipients/R-123/accounts/A-123")
+      .to_return(status: 200, body: recipient_account_response)
+
+    account = @gateway.recipient_account.find('R-123', 'A-123')
+
+    assert_equal({ 'brand' => 'visa', 'last4' => '4242' }, account.cardDetails)
+    assert_equal({ 'city' => 'San Francisco', 'country' => 'US' }, account.mailing)
+    assert_equal '+15555550123', account.phoneNumber
+  end
+
   def test_gateway_exposes_verification_and_trust_aliases
     assert_same @gateway.verification, @gateway.trust
   end
@@ -116,5 +147,17 @@ class GatewayParityTest < Test::Unit::TestCase
 
   def invoice_payment_search_response
     '{"ok":true,"invoicePayments":[{"invoiceId":"I-123","invoiceLineId":"IL-123","paymentId":"P-123","amount":{"value":"150.00","currency":"EUR"},"status":"pending","memo":"payment memo","externalId":"payment-external-id_123","tags":["invoice_payment","royalty invoice"],"coverFees":true}]}'
+  end
+
+  def payment_response
+    '{"ok":true,"payment":{"id":"P-123","sourceCurrency":"USD","sourceCurrencyName":"US Dollar","targetCurrency":"CAD","targetCurrencyName":"Canadian Dollar","visibleToRecipient":false}}'
+  end
+
+  def offline_payments_response
+    '{"ok":true,"offlinePayments":[{"id":"OP-123","recipientId":"R-123","amount":"10.00","currency":"USD","activityCount":2}]}'
+  end
+
+  def recipient_account_response
+    '{"ok":true,"account":{"id":"A-123","recipientId":"R-123","cardDetails":{"brand":"visa","last4":"4242"},"mailing":{"city":"San Francisco","country":"US"},"phoneNumber":"+15555550123"}}'
   end
 end


### PR DESCRIPTION
## Summary
- Add a generic `Gateway#request` / `Client#request` entrypoint for unsupported or newly documented Trolley API endpoints.
- Treat any 2xx HTTP response as success while preserving existing typed gateway methods.
- Add typed, additive helpers for balance aliases, top-level payment lookup, and Trust verification endpoints.
- Expose documented invoice payment response fields: `status`, `memo`, `externalId`, `tags`, and `coverFees`.
- Expose additional documented response fields on `Payment`, `OfflinePayment`, and `RecipientAccount` models.
- Add offline unit coverage for generic requests, Trust calls, balance/payment parity helpers, response-field mapping, delete variants, and pass-through documented body fields.
- Refresh `Gemfile.lock` to match the current gemspec dependency set.

## Related docs PR
- Paired with trolley/developer-documentation#193, which updates the SDK surface audit, Ruby runtime examples, and cross-interface coverage reporting.
- The docs PR validates the new Ruby examples against this branch so the docs can merge alongside the SDK update.

## Test plan
- [x] bundle install
- [x] bundle exec ruby test/unit/GatewayParityTest.rb
- [x] bundle exec rake unit_tests
- [x] bundle exec rubocop lib/trolley/Client.rb lib/trolley/Gateway.rb lib/trolley/gateways/BalanceGateway.rb lib/trolley/gateways/PaymentGateway.rb lib/trolley/gateways/VerificationGateway.rb test/unit/ClientRequestTest.rb test/unit/GatewayParityTest.rb
- [x] bundle exec rubocop lib/trolley/InvoicePayment.rb test/unit/GatewayParityTest.rb
- [x] bundle exec rubocop lib/trolley/Payment.rb lib/trolley/OfflinePayment.rb lib/trolley/RecipientAccount.rb test/unit/GatewayParityTest.rb
- [x] bundle exec rake build
- [x] python3 scripts/api_docs/run_live_audit.py sdk-surface --language ruby --sdk-root /Users/barnett/Documents/code/ruby-sdk --output tests/api_docs/sdk_surface_audit_ruby_report.json
- [x] python3 scripts/api_docs/run_live_audit.py sdk --languages ruby --runtime-mode bounded --bounded-max-items 200 --output tests/api_docs/sdk_runtime_audit_ruby_report.json
- [x] python3 scripts/api_docs/run_live_audit.py responses --strict --output tests/api_docs/response_example_audit_report.json
- [x] python3 scripts/api_docs/run_live_audit.py coverage --json-output tests/api_docs/cross_interface_coverage_report.json --csv-output tests/api_docs/cross_interface_coverage_report.csv

## Coverage result
- Ruby SDK surface audit: `supported=49`, `missing=0`, `rest_only=13`.
- Ruby SDK runtime audit in docs PR: `passed=53`, `failed=0`.
- Cross-interface coverage: `sdk_ruby` and `sdk_surface_ruby` have zero warn/fail cells.
- CircleCI is green for this PR.